### PR TITLE
Add note about branch naming conventions

### DIFF
--- a/guides/Git.md
+++ b/guides/Git.md
@@ -23,6 +23,8 @@ git pull
 git checkout -b ${branch_name} # (* - check fusnote)
 ```
 
+N.B. Branch names should be indicative of their function and be hyphenated e.g. `blog-comments`
+
 ## Commit
 
 Make frequent, coherent commits that you will thank yourself for later.


### PR DESCRIPTION
Why:
- Consistency improves efficiency

This change addresses the need by:
- Adding a note about branch naming conventions
