### PR TITLE
Add Slim lint

### DIFF
--- a/guides/code-style/.jshint.yml
+++ b/guides/code-style/.jshint.yml
@@ -1,0 +1,32 @@
+files: ['**/*.js']
+exclude_paths: ['vendor/assets/javascripts']
+options:
+  asi: false
+  bitwise: true
+  browser: true
+  camelcase: true
+  curly: true
+  forin: true
+  immed: true
+  latedef: nofunc
+  maxlen: 80
+  newcap: true
+  noarg: true
+  noempty: true
+  nonew: true
+  predef: [
+    '$',
+    'jQuery',
+    'jasmine',
+    'beforeEach',
+    'describe',
+    'expect',
+    'it',
+    'angular',
+    'inject',
+    'module'
+  ]
+  quotmark: true
+  trailing: true
+  undef: true
+  unused: true

--- a/guides/code-style/.slim-lint.yml
+++ b/guides/code-style/.slim-lint.yml
@@ -1,0 +1,47 @@
+skip_frontmatter: false
+
+linters:
+  CommentControlStatement:
+    enabled: true
+
+  ConsecutiveControlStatements:
+    enabled: true
+    max_consecutive: 2
+
+  EmptyControlStatement:
+    enabled: true
+
+  RedundantDiv:
+    enabled: true
+
+  LineLength:
+    enabled: true
+    max: 80
+
+  RuboCop:
+    enabled: true
+
+    ignored_cops:
+      - Lint/BlockAlignment
+      - Lint/EndAlignment
+      - Lint/Void
+      - Metrics/LineLength
+      - Style/AlignHash
+      - Style/AlignParameters
+      - Style/BlockNesting
+      - Style/FileName
+      - Style/FirstParameterIndentation
+      - Style/FrozenStringLiteralComment
+      - Style/IfUnlessModifier
+      - Style/IndentationConsistency
+      - Style/IndentationWidth
+      - Style/Next
+      - Style/TrailingBlankLines
+      - Style/TrailingWhitespace
+      - Style/WhileUntilModifier
+
+  TagCase:
+    enabled: true
+
+  TrailingWhitespace:
+    enabled: true

--- a/guides/code-style/Readme.md
+++ b/guides/code-style/Readme.md
@@ -13,13 +13,17 @@ on the team is comfortable with any adjustments you make.
 
 ## Configs
 
-We use a number of tools to enforce style compliance; Rubocop for Ruby lints and
-SCSS Lint for, well, SCSS lints.
+We use a number of tools to enforce style compliance:
+
+  * JSHint for Javascript lints
+  * Rubocop for Ruby lints
+  * SCSS Lint for, well, SCSS lints
 
 First, you need to add the gems to your project's Gemfile:
 
 ```ruby
 group :development, :test do
+  gem 'jshint', require: false
   gem 'rubocop', require: false
   gem 'scss_lint', require: false
 end
@@ -30,6 +34,7 @@ Then you need to add some configs that implement our styles.
 The following is a list of configuration files you're encouraged to use in a new
 project:
 
+* [JSHint](.jshint.yml)
 * [Rubocop](.rubocop.yml)
 * [SCSS Lint](.scss-lint.yml)
 

--- a/guides/code-style/Readme.md
+++ b/guides/code-style/Readme.md
@@ -17,7 +17,8 @@ We use a number of tools to enforce style compliance:
 
   * JSHint for Javascript lints
   * Rubocop for Ruby lints
-  * SCSS Lint for, well, SCSS lints
+  * SCSS Lint, for SCSS lints
+  * Slim Lint, well, for Slim lints
 
 First, you need to add the gems to your project's Gemfile:
 
@@ -26,6 +27,7 @@ group :development, :test do
   gem 'jshint', require: false
   gem 'rubocop', require: false
   gem 'scss_lint', require: false
+  gem 'slim_lint', require: false
 end
 ```
 
@@ -37,6 +39,7 @@ project:
 * [JSHint](.jshint.yml)
 * [Rubocop](.rubocop.yml)
 * [SCSS Lint](.scss-lint.yml)
+* [Slim Lint](.slim-lint.yml)
 
 These files should go into your project's root directory.
 

--- a/guides/code-style/lints.rake
+++ b/guides/code-style/lints.rake
@@ -1,8 +1,17 @@
 require 'rubocop/rake_task'
 
-RuboCop::RakeTask.new
+task :jshint_custom do
+  puts 'Running JS lints...'
+  if system("bundle exec rake jshint:lint['.jshint.yml']")
+    puts "\e[32mAll good!\e[0m"
+  else
+    exit 1
+  end
+end
+task default: :jshint_custom
 
-task :default => :rubocop
+RuboCop::RakeTask.new
+task default: :rubocop
 
 task :scss_lint do
   puts 'Running SCSS lints...'
@@ -12,5 +21,4 @@ task :scss_lint do
     exit 1
   end
 end
-
-task :default => :scss_lint
+task default: :scss_lint

--- a/guides/code-style/lints.rake
+++ b/guides/code-style/lints.rake
@@ -1,4 +1,5 @@
 require 'rubocop/rake_task'
+require 'slim_lint/rake_task'
 
 task :jshint_custom do
   puts 'Running JS lints...'
@@ -22,3 +23,8 @@ task :scss_lint do
   end
 end
 task default: :scss_lint
+
+SlimLint::RakeTask.new do |t|
+  t.config = '.slim-lint.yml'
+end
+task default: :slim_lint


### PR DESCRIPTION
Why:
- We are beginning the transition to the use of Slim for templating in
  rails apps and we want to ensure we get off on the right foot

This change addresses the need by:
- Adding a default config for Slim lint
- Updating Readme
