### PR TITLE
Add JSHint linter

### DIFF
--- a/guides/code-style/.jshint.yml
+++ b/guides/code-style/.jshint.yml
@@ -1,0 +1,32 @@
+files: ['**/*.js']
+exclude_paths: ['vendor/assets/javascripts']
+options:
+  asi: false
+  bitwise: true
+  browser: true
+  camelcase: true
+  curly: true
+  forin: true
+  immed: true
+  latedef: nofunc
+  maxlen: 80
+  newcap: true
+  noarg: true
+  noempty: true
+  nonew: true
+  predef: [
+    '$',
+    'jQuery',
+    'jasmine',
+    'beforeEach',
+    'describe',
+    'expect',
+    'it',
+    'angular',
+    'inject',
+    'module'
+  ]
+  quotmark: true
+  trailing: true
+  undef: true
+  unused: true

--- a/guides/code-style/Readme.md
+++ b/guides/code-style/Readme.md
@@ -13,13 +13,17 @@ on the team is comfortable with any adjustments you make.
 
 ## Configs
 
-We use a number of tools to enforce style compliance; Rubocop for Ruby lints and
-SCSS Lint for, well, SCSS lints.
+We use a number of tools to enforce style compliance:
+
+  * JSHint for Javascript lints
+  * Rubocop for Ruby lints
+  * SCSS Lint for, well, SCSS lints
 
 First, you need to add the gems to your project's Gemfile:
 
 ```ruby
 group :development, :test do
+  gem 'jshint', require: false
   gem 'rubocop', require: false
   gem 'scss_lint', require: false
 end
@@ -30,6 +34,7 @@ Then you need to add some configs that implement our styles.
 The following is a list of configuration files you're encouraged to use in a new
 project:
 
+* [JSHint](.jshint.yml)
 * [Rubocop](.rubocop.yml)
 * [SCSS Lint](.scss-lint.yml)
 

--- a/guides/code-style/lints.rake
+++ b/guides/code-style/lints.rake
@@ -1,8 +1,13 @@
 require 'rubocop/rake_task'
 
-RuboCop::RakeTask.new
+task :jshint_custom do
+  puts 'Running JS lints...'
+  Rake::Task['jshint:lint'].invoke('.jshint.yml')
+end
+task default: :jshint_custom
 
-task :default => :rubocop
+RuboCop::RakeTask.new
+task default: :rubocop
 
 task :scss_lint do
   puts 'Running SCSS lints...'
@@ -12,5 +17,4 @@ task :scss_lint do
     exit 1
   end
 end
-
-task :default => :scss_lint
+task default: :scss_lint


### PR DESCRIPTION
Why:
- JS can get pretty unruly, so this linter will aim to round up those
  missing semi-colons!

This change addresses the need by:
- Adding jshint rake task to lints.rake
- Adding custom config in .jshint.yml
- Updating the Readme
