### PR TITLE
Extend guide for developing with Shopify

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,10 @@ better.
   * [Git Pull Requests](/scripts/git_merge_pull_request.sh)
   * [Heroku Sync DB to Local](/scripts/heroku_sync_db_to_local.sh)
   * [Heroku Remotes](/scripts/git_heroku_add.sh)
+  * [Shopify](/scripts/shopify)
+    * [Circle Config](/scripts/shopify/circle.yml)
+    * [Grunt Config](/scripts/shopify/config.yml)
+    * [Gruntfile.js](/scripts/shopify/gruntfile.js)
 
 # The Why?
 At DVELP, we are about loving what we do. We love to learn, we love to

--- a/guides/Shopify.md
+++ b/guides/Shopify.md
@@ -1,12 +1,26 @@
-# Deploying To Shopify With CircleCI
+# Developing and Deploying to Shopify
 
 ## The Challenge
 
 The primary challenge we faced when developing for Shopify was that the codebase checked in to Git was getting out of sync with the codebase deployed to Shopify. This issue was compounded when using the same theme on multiple stores e.g. for simple staging + production environments or in more complex, multi-geo scenarios.
 
+The root of the issue revolves around Shopify's lack of support for nested
+folders. Amongst other things, this presents challenges with:
+
+  * Imagery and user defined settings
+  * Javascript and stylesheet compilation
+
 ## The Solution
 
-To combat the issue, we configured the CI server, in this case CircleCI, to manage all of the deployments for us. We hooked the `master` branch to deploy direct to the production store and the `staging` branch to the staging store.
+1) [Ignore compiled assets](../scripts/shopify/.gitignore) from SCM
+
+2) Set-up [Grunt](../scripts/shopify/gruntfile.js) to sync, process and compile assets
+
+3) [Deploy](#deployment) to Shopify
+
+## Deployment
+
+To facilate deployment and improve syncing between store and code base, we configured the CI server, in this case CircleCI, to manage all of the deployments for us. We hooked up the `master` branch to deploy direct to the production store and the `staging` branch to the staging store.
 
 ### Tools
 
@@ -24,11 +38,11 @@ deployment:
   production:
     branch: master
     commands:
-      - grunt shopify:upload
+      - grunt deploy
   staging:
     branch: staging
     commands:
-      - grunt shopify:upload
+      - grunt deploy
 ```
 
 * Update `gruntfile.js` file to read the Shopify credentials from the environment variables:
@@ -63,3 +77,6 @@ The `IS_CI` variable determines that we are deploying via CI, in which case we r
 * `PRODUCTION_SHOPIFY_PASSWORD`
 
 * `PRODUCTION_SHOPIFY_STORE`
+
+## Get 'em
+We've added the complete set of files [here](../scripts/shopify) for your reference.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -60,3 +60,16 @@ Alias:
 ```
 gm pr = git_merge_pull_request.sh
 ```
+
+# Shopify
+
+Get them:
+  * Grunt config: [config.yml](shopify/config.yml)
+  * Gruntfile: [config.yml](shopify/confile.js)
+
+Developing and deploying to Shopify with ease! Read more [here](../guides/Shopify.md).
+
+Example:
+```
+grunt deploy
+```

--- a/scripts/shopify/.gitignore
+++ b/scripts/shopify/.gitignore
@@ -1,0 +1,12 @@
+# Assets
+assets/*.jpg
+assets/*.ico
+assets/*.png
+assets/application.css
+assets/application.js
+assets/postcss/*
+snippets/svgs.liquid
+
+# Settings
+config/settings_data.json
+config.yml

--- a/scripts/shopify/circle.yml
+++ b/scripts/shopify/circle.yml
@@ -1,0 +1,9 @@
+deployment:
+  production:
+    branch: master
+    commands:
+      - grunt deploy
+  staging:
+    branch: staging
+    commands:
+      - grunt deploy

--- a/scripts/shopify/config.yml
+++ b/scripts/shopify/config.yml
@@ -1,0 +1,11 @@
+---
+:api_key: 'API Key'
+:password: 'Password'
+:store: 'Shopify store ID'
+:theme_id: 'Theme ID'
+:ignore_files:
+  - assets/javascripts/
+  - assets/images/
+  - assets/sass/
+  - config/settings_data.json
+  - node_modules

--- a/scripts/shopify/gruntfile.js
+++ b/scripts/shopify/gruntfile.js
@@ -1,0 +1,179 @@
+yaml = require('js-yaml');
+fs = require('fs');
+
+// Set configuration variables from local config.yml or CI ENV variables
+if(process.env.IS_CI) {
+  if(process.env.CIRCLE_BRANCH == 'master') {
+    var environment = 'PRODUCTION';
+  } else {
+    var environment = 'STAGING';
+  }
+  var deployConfig = {};
+  deployConfig[':api_key'] = process.env[environment + '_SHOPIFY_API_KEY'];
+  deployConfig[':password'] = process.env[environment + '_SHOPIFY_PASSWORD'];
+  deployConfig[':store'] = process.env[environment + '_SHOPIFY_STORE'];
+} else {
+  var deployConfig = yaml.safeLoad(fs.readFileSync('./config.yml', 'utf8'));
+}
+
+try {
+  var required_keys = [':api_key', ':password', ':store'];
+  required_keys.forEach(function(key) {
+    if (!deployConfig[key] || deployConfig[key].trim().length === 0) {
+      console.error('Please set ' + key + ' variable.');
+    }
+  });
+} catch (e) {
+  console.error('An error occured while reading the configuration.');
+  console.error(e);
+}
+
+module.exports = function(grunt) {
+  grunt.initConfig({
+    // Run autoprefixer on sass files
+    postcss: {
+      options: {
+        map: true,
+        processors: [
+          require('autoprefixer')({
+            browsers: [
+              '> 0.5%',
+              'last 2 versions',
+              'Firefox ESR',
+              'Opera 12.1',
+              'ie >6'
+            ]
+          })
+        ]
+      },
+      dist: {
+        files: [
+          {
+            src: 'assets/postcss/*.css',
+            dest: 'assets/',
+            expand: true,
+            flatten: true
+          }
+        ]
+      }
+    },
+
+    // Compile sass files
+    sass: {
+      compile: {
+        options: {
+          sourcemap: 'none',
+          style: 'compressed',
+          loadPath: 'assets/sass/vendor',
+        },
+        files: [
+          {
+            expand: true,
+            cwd: 'assets/sass',
+            src: ['**/*.scss'],
+            dest: 'assets/postcss',
+            ext: '.css',
+          }
+        ],
+      },
+    },
+
+    // Configuration for deploying to shopify
+    shopify: {
+      options: {
+        api_key: deployConfig[':api_key'],
+        password: deployConfig[':password'],
+        url: deployConfig[':store'],
+        theme: deployConfig[':theme_id'],
+        disable_growl_notifications: false,
+      },
+    },
+
+    // Create SVG sprite
+    svgstore: {
+      options: {
+        cleanupdefs: true,
+      },
+      default : {
+        files: {
+          'snippets/icons.svg.liquid': ['assets/svgs/*.svg']
+        },
+      },
+    },
+
+    // Move assets from images/assets to primary assets directory
+    sync: {
+      main: {
+        files: [
+          {
+            expand: true,
+            cwd: 'assets/images',
+            src: ['**'],
+            dest: 'assets',
+          },
+        ],
+        verbose: true,
+      },
+    },
+
+    // Uglify javascripts
+    uglify: {
+      my_target: {
+        files: {
+          'assets/application.js': [
+            'assets/javascripts/vendor/jquery/*.js',
+            'assets/javascripts/vendor/**/*.js',
+            'assets/javascripts/public/**/*.js'
+          ]
+        },
+      },
+    },
+
+    // Watch for changes to files and run the associated tasks
+    watch: {
+      css: {
+        files: ['assets/sass/**/*.scss'],
+        tasks: ['sass', 'postcss'],
+      },
+      shopify: {
+        files: [
+          'assets/*',
+          'config/**',
+          'layout/**',
+          'locales/**',
+          'snippets/**',
+          'templates/**',
+        ],
+        tasks: ['shopify'],
+      },
+      svgstore: {
+        files: ['assets/svgs/*.svg'],
+        tasks: ['svgstore'],
+      },
+      sync: {
+        files: ['assets/images/**'],
+        tasks: ['sync'],
+      },
+      uglify: {
+        files: ['assets/javascripts/**/*.js'],
+        tasks: ['uglify'],
+      },
+    },
+  });
+
+  grunt.loadNpmTasks('grunt-contrib-concat');
+  grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-contrib-sass');
+  grunt.loadNpmTasks('grunt-contrib-uglify');
+  grunt.loadNpmTasks('grunt-shopify');
+  grunt.loadNpmTasks('grunt-svgstore');
+  grunt.loadNpmTasks('grunt-sync');
+  grunt.loadNpmTasks('grunt-postcss');
+
+  grunt.registerTask('default',
+    ['sync', 'sass', 'postcss', 'uglify', 'svgstore', 'watch']
+  );
+  grunt.registerTask('deploy',
+    ['sync', 'sass', 'postcss', 'uglify', 'svgstore', 'shopify:upload']
+  );
+};


### PR DESCRIPTION
Why:
- Shopify has some complexities, especially when it comes to syncing
  code checked into SCM with the relevant Shopify stores

This change addresses the need by:
- Adding the full gruntfile.js and config.yml
- Extending the Shopify guide
