### PR TITLE
Added sass installation to circle configs example

### DIFF
--- a/scripts/shopify/circle.yml
+++ b/scripts/shopify/circle.yml
@@ -2,8 +2,10 @@ deployment:
   production:
     branch: master
     commands:
+      - gem install sass
       - grunt deploy
   staging:
     branch: staging
     commands:
+      - gem install sass
       - grunt deploy


### PR DESCRIPTION
Why:
- CirclCI is using old sass gem version by default, so we need to
  install it every time
