### PR TITLE
Add Harvest Forecast Guide to DVELP Cookbook

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,6 +10,7 @@ better.
 * [Guides](/guides)
   * [Code Style](/guides/code-style/Readme.md)
   * [Git](/guides/Git.md)
+  * [Harvest Forecast] (/guides/harvest-forecast.md)
   * [Heroku](/guides/Heroku%20Pipeline.md)
   * [Ruby gems](/guides/Creating%20Ruby%20Gems%20bespoke%20for%20DVELP.md)
   * [Shopify](/guides/Shopify.md)

--- a/guides/harvest-forecast.md
+++ b/guides/harvest-forecast.md
@@ -1,0 +1,21 @@
+#Harvest Forecast
+A quick guide to planning resources in Harvest Forecast at DVELP.
+
+##So what is it?
+Harvest Forecast is a web-based resource planning tool for allocating expected work time across multiple users and projects. It syncs with Harvest, conveniently allowing for comparisons of planned vs. actual hours worked. 
+
+##How do we use it at DVELP? 
+We take a bottom up approach to planning at DVELP. We trust in the team's expertise to estimate how much time they need for the work on hand.
+
+In the **Projects** view, Team members are added to their active projects for their expected hours effort per day needed. We plan in support for active projects against that project directly, particularly for the critical time after launch.  We also have team members planned for general ongoing support to catch the odd help request from our long term clients. Public holidays and vacations are accounted for, as are internal R&D projects. 
+
+We target having the team planned at 80% of capacity to allow some contingency in case of illness or last minute requests. 
+
+When the dust settles, we look at the **Team** view to see if anyone has too much or too little on their plate and work with everyone to share the load. 
+
+##Planning Flow 
+New requests and changes are planned into Forecast daily. Any changes to the current week are reviewed with the impacted teams in real time. 
+
+Full projects are estimated and planned in their entirety. Small improvement works (<2 days) are planned in detail across the next two weeks. 
+
+Every Friday we review the past week and discuss the upcoming week with the team so that everyone is on the same page and ready to roll first thing Monday morning. 


### PR DESCRIPTION
Add Harvest Forecast guide and update read me with link

DVELP uses Forecast to plan our time and estimate availability before
taking on new work. Share the process of how DVELP plans resources in
our GitHub cookbook
