### PR TITLE
Changed Scss lint

### DIFF
--- a/guides/code-style/.scss-lint.yml
+++ b/guides/code-style/.scss-lint.yml
@@ -6,7 +6,7 @@ linters:
   ImportPath:
     enabled: false
   LeadingZero:
-    style: include_zero
+    style: exclude_zero
   MergeableSelector:
     enabled: false
   NameFormat:
@@ -19,3 +19,149 @@ linters:
     enabled: true
     convention: hyphenated_lowercase
     class_convention: '^(?:is)\-[a-z][a-zA-Z0-9]*$|^(?!is)[a-z][a-zA-Z0-9]*(?:\-[a-z][a-zA-Z0-9]*)?(?:\-\-[a-z0-9][a-zA-Z0-9]*)?$'
+  EmptyLineBetweenBlocks:
+    enabled: false
+  QualifyingElement:
+    allow_element_with_attribute: true
+  PropertySortOrder:
+    order:
+      - content
+      # Box
+      - position
+      - top
+      - right
+      - bottom
+      - left
+      - display
+      - vertical-align
+      - overflow
+      - clip
+      - float
+      - clear
+      - flex
+      - flex-basis
+      - flex-direction
+      - flex-flow
+      - flex-grow
+      - flex-shrink
+      - flex-wrap
+      - align-content
+      - align-items
+      - align-self
+      - justify-content
+      - order
+      - width
+      - min-width
+      - max-width
+      - height
+      - min-height
+      - max-height
+      - padding
+      - padding-top
+      - padding-right
+      - padding-bottom
+      - padding-left
+      - margin
+      - margin-top
+      - margin-right
+      - margin-bottom
+      - margin-left
+      - columns
+      - column-gap
+      - column-fill
+      - column-rule
+      - column-span
+      - column-count
+      - column-width
+      # Border
+      - border
+      - border-top
+      - border-right
+      - border-bottom
+      - border-left
+      - border-width
+      - border-top-width
+      - border-right-width
+      - border-bottom-width
+      - border-left-width
+      - border-style
+      - border-top-style
+      - border-right-style
+      - border-bottom-style
+      - border-left-style
+      - border-radius
+      - border-top-left-radius
+      - border-top-right-radius
+      - border-bottom-left-radius
+      - border-bottom-right-radius
+      - border-color
+      - border-top-color
+      - border-right-color
+      - border-bottom-color
+      - border-left-color
+      - border-collapse
+      - border-spacing
+      - outline
+      - outline-color
+      - outline-offset
+      - outline-style
+      - outline-width
+      - box-shadow
+      # Background
+      - background
+      - background-attachment
+      - background-clip
+      - background-color
+      - background-image
+      - background-repeat
+      - background-position
+      - background-size
+      # Text
+      - color
+      - font
+      - font-size
+      - line-height
+      - font-weight
+      - font-family
+      - font-style
+      - font-smoothing
+      - font-variant
+      - letter-spacing
+      - list-style
+      - text-align
+      - text-decoration
+      - text-indent
+      - text-overflow
+      - text-rendering
+      - text-shadow
+      - text-transform
+      - text-wrap
+      - white-space
+      - word-spacing
+      # Transform & Animation
+      - transform
+      - transform-box
+      - transform-origin
+      - transform-style
+      - transition
+      - transition-delay
+      - transition-duration
+      - transition-property
+      - transition-timing-function
+      - animation
+      - animation-name
+      - animation-duration
+      - animation-timing-function
+      - animation-delay
+      - animation-iteration-count
+      - animation-direction
+      - animation-fill-mode
+      - animation-play-state
+      # Other
+      - table-layout
+      - caption-side
+      - empty-cells
+      - cursor
+      - opacity
+      - visibility
+      - z-index


### PR DESCRIPTION
Why
- Alphabetical order of styles was difficult for reading. We grouped related properties together (positioning, box-model, etc.) for better understanding the essence of the styles by reading few declarations, how element is positioned, it's in flow or not, etc. This allows to review block for properties quickly.

This change addresses the need by:
- Changed property sort order
- Exclude leading zero in styles
- Disabled empty line between blocks
