### PR TITLE
Add -b option to set a target branch

### DIFF
--- a/scripts/git_merge_pull_request.sh
+++ b/scripts/git_merge_pull_request.sh
@@ -1,24 +1,34 @@
 #!/bin/bash -e
+verbose='false'
 
 branch_name=`git symbolic-ref HEAD`
 branch_name=${branch_name##refs/heads/}
+target_branch='master'
 
-if [ "$branch_name" == "master" ]; then
-  echo "You're on master branch, checkout feature branch you want to merge"
+while getopts 'b:' flag; do
+  case "${flag}" in
+    b) target_branch=${OPTARG} ;;
+    v) verbose='true' ;;
+    *) error "Unexpected option ${flag}" ;;
+  esac
+done
+
+if [ "$branch_name" == $target_branch ]; then
+  echo "You're on $target_branch branch, checkout feature branch you want to merge"
   exit 1
 fi
 
 echo "git fetch origin"
 git fetch origin
 
-echo "git rebase origin/master"
-git rebase origin/master
+echo "git rebase origin/${target_branch}"
+git rebase origin/$target_branch
 
 echo "git push -f"
 git push -f
 
-echo "git checkout master"
-git checkout master
+echo "git checkout ${target_branch}"
+git checkout $target_branch
 
 echo "git merge $branch_name"
 git merge $branch_name
@@ -32,4 +42,4 @@ git push origin --delete $branch_name
 echo "git branch -d $branch_name"
 git branch -d $branch_name
 
-echo "$branch_name has been merged into master. All is well!"
+echo "$branch_name has been merged into ${target_branch}. All is well!"

--- a/scripts/git_merge_pull_request.sh
+++ b/scripts/git_merge_pull_request.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -e
-verbose='false'
 
-branch_name=`git symbolic-ref HEAD`
-branch_name=${branch_name##refs/heads/}
+feature_branch=`git symbolic-ref HEAD`
+feature_branch=${feature_branch##refs/heads/}
 target_branch='master'
+verbose='false'
 
 while getopts 'b:' flag; do
   case "${flag}" in
@@ -13,7 +13,7 @@ while getopts 'b:' flag; do
   esac
 done
 
-if [ "$branch_name" == $target_branch ]; then
+if [ "$feature_branch" == $target_branch ]; then
   echo "You're on $target_branch branch, checkout feature branch you want to merge"
   exit 1
 fi
@@ -30,16 +30,16 @@ git push -f
 echo "git checkout ${target_branch}"
 git checkout $target_branch
 
-echo "git merge $branch_name"
-git merge $branch_name
+echo "git merge $feature_branch"
+git merge $feature_branch
 
 echo "git push"
 git push
 
-echo "git push origin --delete $branch_name"
-git push origin --delete $branch_name
+echo "git push origin --delete $feature_branch"
+git push origin --delete $feature_branch
 
-echo "git branch -d $branch_name"
-git branch -d $branch_name
+echo "git branch -d $feature_branch"
+git branch -d $feature_branch
 
-echo "$branch_name has been merged into ${target_branch}. All is well!"
+echo "$feature_branch has been merged into ${target_branch}. All is well!"


### PR DESCRIPTION
Changes:

61890e3 (Tom Mullen, 3 minutes ago)
   Rename branch_name to feature_branch

   Why:

   * The branch_name was a little ambiguous as it could be referring to either
   feature or target branch

   This change addresses the need by:

   * Renaming branch_name to feature_branch

fb2c59f (Tom Mullen, 12 minutes ago)
   Add -b option to allow targets other than master

   Why:

   * Often we want to merge a feature into a target branch other than master

   This change addresses the need by:

   * Using getopts to fetch the -b option, which allows us to set the target
   branch name. If no -b option is passed, it defaults to master