### PR TITLE
Remove ignored_cops from .slim-lint.yml

### DIFF
--- a/guides/code-style/.slim-lint.yml
+++ b/guides/code-style/.slim-lint.yml
@@ -21,25 +21,6 @@ linters:
   RuboCop:
     enabled: true
 
-    ignored_cops:
-      - Lint/BlockAlignment
-      - Lint/EndAlignment
-      - Lint/Void
-      - Metrics/LineLength
-      - Style/AlignHash
-      - Style/AlignParameters
-      - Style/BlockNesting
-      - Style/FileName
-      - Style/FirstParameterIndentation
-      - Style/FrozenStringLiteralComment
-      - Style/IfUnlessModifier
-      - Style/IndentationConsistency
-      - Style/IndentationWidth
-      - Style/Next
-      - Style/TrailingBlankLines
-      - Style/TrailingWhitespace
-      - Style/WhileUntilModifier
-
   TagCase:
     enabled: true
 


### PR DESCRIPTION
Why?
- Many of the items in Style have moved to Layouts namespace in Rubocop
- We aren't actually ignoring any cops that aren't ignored by default,
so this is adding no actual benefit