### PR TITLE
Developer Proficiency guidelines

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,6 +18,9 @@ better.
   * [Shopify](/guides/Shopify.md)
   * [Trello](/guides/trello.md)
 
+* [Handbook](/handbook)
+  * [Developer Proficiency](/handbook/developer-proficiency.md)
+
 * [Scripts](/scripts)
   * [Git Pull Requests](/scripts/git_merge_pull_request.sh)
   * [Heroku Sync DB to Local](/scripts/heroku_sync_db_to_local.sh)

--- a/handbook/developer-proficiency.md
+++ b/handbook/developer-proficiency.md
@@ -1,0 +1,70 @@
+# Developer Proficiency
+
+The following bands are designed to provide a structure to help better
+understand current competencies and act as a starting point for individualised
+discussions around progress.
+
+The criteria set out in each band is by no means exhaustive, but aims to provide
+a solid point of reference.
+
+## D-band
+
+* Pull Requests require multiple rounds of feedback to reach a mergeable state
+* The basics of a language or framework are mastered, but more advanced concepts
+  are unfamiliar
+* Occasional issues following patterns and approaches within existing code bases
+* Most comfortable working on tightly scoped features or routine problems
+* Typically less than 2 years focused on a specific domain in a
+  professional environment
+
+## V-band
+
+* Pull Requests require occassional discussion around approach or implementation
+* Clearly able to identify and follow predefined patterns or approaches in an
+  existing code base
+* Most comfortable working on clearly defined, well scoped features or
+  problems
+* Typically 2-5 years focused on a specific domain in a professional
+  environment
+
+## E-band
+
+* Pull Requests are a tool for communication of new features and a
+  spring-board for higher-level discussions around approach
+* Experienced and comfotable through the entire life-cycle of a feature, from
+  ideation to delivery
+* Can understand business drivers and make solid proposals to the relevant
+  stakeholders for building new features or refining existing ones
+* A subject matter expert in at least one programming environment
+* Typically 5-8 years focused on a specific domain in a professional
+  environment
+
+## L-band
+
+* Pull Requests are a mentoring tool to engage less experienced team mates and
+  showcase best practices
+* Highly adept at running and executing on multiple projects across multiple
+  domains
+* Heavily involved in setting and maintaining professional standards for the
+  organisation as a whole
+* A subject matter expert in a number of programming environments
+* Confident building and running small teams through substantial projects
+* Typically 8-12 years focused on a specific domain in a professional
+  environment
+
+## P-band
+
+* Focus on defining and progressing processes and inovation at a company-wide
+  level
+* Fully capable of designing, owning and running entirely new, non-trivial
+  systems
+* Confident building and running larger teams through long-running, complex
+  projects with multiple-stakeholders
+* Recognised widely in the industry as having made substantial material
+  contributions and considered a subject matter expert by peers
+* Typically 12-15+ years focused on a specific domain in a professional
+  environment
+
+The bands are based on those set out by the team at
+[Basecamp](https://github.com/basecamp/handbook/blob/master/titles-for-programmers.md)
+


### PR DESCRIPTION
Why:

* We don't have a clear way of identifying current competencies of our
team members in a consistent and organised format

This change addresses the need by:

* Defining a set of 'bands' (not rock bands) to help our team mates
better understand their current competencies and clearly define the
steps for progression