### PR TITLE
Add templates and recommendations for best practices

### DIFF
--- a/guides/templates/Readme.md
+++ b/guides/templates/Readme.md
@@ -1,0 +1,15 @@
+# Templates
+
+The following are a collection of templates that will act as a reference point
+for some of the commonly used patterns and approaches throughout our codebases.
+
+The aim of the templates is to help improve consistency of approach not just
+within individual codebases, but across the entire portfolio.
+
+These templates are not designed to be hard and fast rules, or fully functional
+models, rather to act as a common starting point.
+
+  * [Models](models.md)
+  * [Services](services.md)
+  * [Specs](specs)
+

--- a/guides/templates/models.md
+++ b/guides/templates/models.md
@@ -1,0 +1,74 @@
+# Models
+
+The following is a base template for an ActiveRecord model `Customer`.
+
+## Key Points
+
+  * Avoid AR callbacks where possible, prefer [service](services.md) lead
+  architecture
+
+  * Order associations, scopes and validations alphabetically
+
+  * Aim to remove business logic that is not directly related to reading from or
+    writing to the database
+
+## Template
+
+```ruby
+class Customer < ActiveRecord::Base
+  # Inclusions and extensions
+  include Module
+
+  # Associations
+  belongs_to :company
+  has_many :orders
+  has_one :address
+
+  # Validations
+  validates :first_name, presence: true
+  validates :last_name, presence: true
+
+  # Callbacks, in lifecycle, then alphabetical order (if you really have to)
+  before_validation :parse_name
+  after_create :send_email
+
+  # Scopes
+  scope :is_active, -> { where(active: true) }
+
+  # Nested attributes
+  accepts_nested_attributes_for :orders
+
+  # Delegate methods
+  delegate :post_code, to: :address
+
+  # Class methods
+  def self.activate
+    find_each do |customer|
+      customer.update_attributes(active: true)
+    end
+  end
+
+  # Instance methods
+  def age
+    calculate_age(dob: dob)
+  end
+
+  # Protected methods
+  protected
+
+  def parse_name
+    # some logic
+  end
+
+  # Private methods
+  private
+
+  def send_email
+    # we shouldn't send emails from AR models
+  end
+
+  def calculate_age(dob:)
+    # some calculation
+  end
+end
+```

--- a/guides/templates/services.md
+++ b/guides/templates/services.md
@@ -1,0 +1,84 @@
+# Services
+
+As our applications grow in size we often find our ActiveRecord objects
+getting increasingly bloated, containing more and more business logic that doesn't really belong. We have already committed to skinny controllers, so we turn to services for help.
+
+The following is a collection of services that will help manage the lifecycle of
+an `Order` object.
+
+## Key Points
+
+  * Put services in the `app/services/` directory
+
+  * Don't call services services e.g. `order_service.rb`. It's in the services
+    directory, we know it's a service
+
+  * When creating services for ActiveRecord objects, create folders with the
+    plural form of the name e.g. `app/services/orders/`
+
+## Template
+
+```ruby
+# app/services/orders/creator.rb
+module Orders
+  class Creator
+    def initialize(params: {})
+      self.params = params
+    end
+
+    def create
+      order = Order.new(params)
+      if order.save
+        take_payment(order)
+        send_email(order)
+      end
+
+      order
+    end
+
+    private
+
+    attr_accessor :params
+
+    def take_payment(order)
+      Payments::Creator.new(order: order).create
+    end
+
+    def send_email(order)
+      OrderMailer.confirmation(order).deliver_now
+    end
+  end
+end
+
+# app/services/orders/updater.rb
+module Orders
+  class Updator
+    def initialize(order:, params: {})
+      self.order = order
+      self.params = params
+    end
+
+    def update
+      result = order.update_attributes(params)
+
+      if order.cancelled?
+        process_refund
+        send_cancellation_email
+      end
+
+      result
+    end
+
+    private
+
+    attr_accessor :order, :params
+
+    def process_refund
+    end
+
+    def send_cancellation_email
+      OrderMailer.cancellation(order).deliver_now
+    end
+  end
+end
+```

--- a/guides/templates/specs/Readme.md
+++ b/guides/templates/specs/Readme.md
@@ -1,0 +1,90 @@
+# Specs
+
+Specs (we use [RSpec](http://rspec.info)) are crucial to building scalable applications. They not only help verify the implementation of our code and how new features interact with it, but also provide clear guidelines to our future selves about the expected behaviour of an application.
+
+Clearly defined and well implemented specs will help us refactor with ease and
+ship with confidence.
+
+## Rspec and Rails
+
+Rails applications typically have the following groupings of specs:
+
+### Unit
+
+Unit tests cover lower-level functionality of individual classes or methods.
+
+  * [Controllers](controllers.md)
+  * [Helpers](helpers.md)
+  * [Models](models.md)
+  * [Mailers](mailers.md)
+  * [Services](services.md)
+  * [Views](views.md)
+
+### Integration
+
+Integration tests are behavioural driven and in most cases will replicate the
+expected experience from a 'first user' perspective. They help to decouple
+behviour from implementation, allowing for easier refactoring, and will ensure
+that the individual components (units) of an application work well together.
+
+  * [Features](features.md)
+  * [Requests](requests.md)
+
+## Recommendations
+
+The following are key recommendations that will help to keep your specs
+manageable and more enjoyable to code with as your application grows in size.
+
+### Test in Four Phases
+
+We typically try to structure each individual test into four phases:
+
+  * setup
+  * exercise
+  * verify
+  * teardown (most often handled by the test suite)
+
+The overarching goal is to improve readability and consistency. By testing in
+four phases, you should have everything you need to understand the logic
+contained within the test.
+
+A worked example is as follows:
+
+```ruby
+it 'sets a uuid for the customer' do
+  # setup
+  attrs = FactoryGirl.attributes_for(:customer)
+  customer = Customer.new(attrs)
+
+  # excercise
+  customer.save
+
+  # verify
+  expect(customer.uuid).to_not be_nil
+end
+```
+
+### Focus On Behaviour, Not Implementation
+
+By focusing on the behaviour of your individual methods, or features, your test suite becomes much more robust and will offer two key advantages:
+
+  * Tests are less brittle as they are decoupled from implementation
+  * Refactoring is quicker and you will have a greater level of confidence the
+    expected behaviour of the app has not changed
+
+### Use let With Great Caution
+
+  * [Let's Talk About This](https://dvelp.co.uk/articles/lets-talk-about-this)
+  * [Let's Not](https://robots.thoughtbot.com/lets-not)
+  * [My Issues With Let](https://robots.thoughtbot.com/my-issues-with-let)
+
+## References
+
+There are many, many articles and theories about how and what to test. The
+templates above are a very high-level examples of how we would approach our
+test-suite, but I highly recommend a read of the following:
+
+  * [Better Specs](http://www.betterspecs.org/)
+  * [The Illusion of TDD](http://dncrht.github.io/2017/03/17/the-illusion-of-tdd.html)
+  * [TDD is Dead. Long Live Testing.](http://david.heinemeierhansson.com/2014/tdd-is-dead-long-live-testing.html)
+

--- a/guides/templates/specs/controllers.md
+++ b/guides/templates/specs/controllers.md
@@ -1,0 +1,15 @@
+# Controller Specs
+
+Rails 5 saw the deprecation of commonly used helper methods `assigns` and
+`assert_template`. It was deemed, and rightly so, that these methods lead to
+brittle tests that care too much about implementation details.
+
+Why should a test care that a specific instance variable was created or that a
+specific action file is responsible for the output of an action? In short, they
+shouldn't.
+
+The focus, upon advice from both Rails core and RSpec teams, has therefore
+shifted to more robust integration tests.
+
+You can read this [request specs guide](requests.mb) for a worked example.
+

--- a/guides/templates/specs/features.md
+++ b/guides/templates/specs/features.md
@@ -1,0 +1,46 @@
+# Festure Specs
+
+We leverage feature specs to mimic the 'first user' of our application in an
+environment with as little stubbing as is possible.
+
+The specs will run through primary customer 'flows' to ensure that all the
+components of our app work well together and, most importantly, the consumer
+experiences the expected behaviour.
+
+Feature specs differ from unit specs, in that individual specs may have
+multiple expectations.
+
+An example of a feature spec is as follows:
+
+```ruby
+require 'rails_helper'
+
+RSpec.feature 'subscribing to a the newsletter', js: true do
+  before(:each) do
+    ENV['MAILCHIMP_API_KEY'] = 'abc-def'
+    ENV['MAILCHIMP_LIST_ID'] = '123'
+  end
+
+  context 'email is valid' do
+    it 'subscribes the customer' do
+      visit root_path
+
+      fill_in 'newsletter_subscriber_email', with: 'tom@dvelp.co.uk'
+      click_button 'Subscribe'
+
+      expect(page).to have_content("You're in!")
+    end
+  end
+
+  context 'email is invalid' do
+    it 'does NOT subscribe the customer' do
+      visit root_path
+
+      fill_in 'newsletter_subscriber_email', with: 'tom-dvelp.co.uk'
+      click_button 'Subscribe'
+
+      expect(page).to have_content('Houston, we have a problem.')
+    end
+  end
+end
+```

--- a/guides/templates/specs/helpers.md
+++ b/guides/templates/specs/helpers.md
@@ -1,0 +1,43 @@
+# Helper Specs
+
+With helpers being modules, their associated specs are typically low-level unit
+tests on the individual methods within.
+
+Example:
+
+```ruby
+require 'rails_helper'
+
+RSpec.describe CustomersHelper, type: :helper do
+  describe '#full_name(customer)' do
+    context 'customer has a middle name' do
+      it 'returns first middle and last names' do
+        customer = FactoryGirl.build_stubbed(
+          :customer,
+          first_name: 'Tom',
+          middle_name: 'Ruby',
+          last_name: 'Mullen'
+        )
+
+        result = helper.full_name(customer)
+
+        expect(result).to eq('Tom Ruby Mullen')
+      end
+    end
+
+    context 'customer does not have a middle name' do
+      it 'returns first and last names' do
+        customer = FactoryGirl.build_stubbed(
+          :customer,
+          first_name: 'Tom',
+          last_name: 'Mullen'
+        )
+
+        result = helper.full_name(customer)
+
+        expect(result).to eq('Tom Mullen')
+      end
+    end
+  end
+end
+```

--- a/guides/templates/specs/mailers.md
+++ b/guides/templates/specs/mailers.md
@@ -1,0 +1,29 @@
+# Mailer Specs
+
+Mailer specs are often very terse and we focus on ensuring the following are as
+expected:
+
+  * Subject line
+  * From
+  * To
+  * Body
+
+```ruby
+require 'rails_helper'
+
+RSpec.describe CustomerMailer, type: :mailer do
+  describe 'welcome' do
+    let(:mail) { CustomerMailer.welcome }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Welcome')
+      expect(mail.to).to eq(['customer@dvelp.co.uk'])
+      expect(mail.from).to eq(['team@dvelp.co.uk'])
+    end
+
+    it 'renders the body' do
+      expect(mail.body.encoded).to match('Hi')
+    end
+  end
+end
+```

--- a/guides/templates/specs/models.md
+++ b/guides/templates/specs/models.md
@@ -1,0 +1,80 @@
+# Model Specs
+
+ActiveRecord makes up the single largest part of the Rails framework, so it
+stands to reason that your model specs can have many components covering
+associations, delegations, scopes, validations etc.
+
+To help wrangle model specs and focus on the 'value add' more quickly, we
+recommend the following libraries:
+
+  * [Shoulda Callback Matchers](https://github.com/jdliss/shoulda-callback-matchers)
+  * [Shoulda Matchers](https://github.com/thoughtbot/shoulda-matchers)
+  * [Test After Commit](https://github.com/grosser/test_after_commit)
+
+An example of a typical model spec at DVELP looks like this:
+
+```ruby
+require 'rails_helper'
+
+describe Customer, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:company) }
+    it { is_expected.to have_many(:orders) }
+    it { is_expected.to have_one(:address) }
+  end
+
+  describe 'callbacks' do
+    it { is_expected.to callback(:parse_name).before(:validation) }
+  end
+
+  describe 'delegates' do
+    it { is_expected.to delegate_method(:post_code).to(:address) }
+  end
+
+  describe 'nested attributes' do
+    it { is_expected.to accept_nested_attributes_for(:orders) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:company) }
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to validate_uniqueness_of(:email) }
+    it { is_expected.to validate_presence_of(:first_name) }
+    it { is_expected.to validate_presence_of(:last_name) }
+  end
+
+  describe '.is_active' do
+    it 'returns active customers' do
+      active_customer = FactoryGirl.create(:customer, active: true)
+      _inactive_customer = FactoryGirl.create(:customer, active: false)
+
+      result = described_class.is_active
+
+      expect(result).to match_array([active_customer])
+    end
+  end
+
+  describe '.activate' do
+    it 'marks all records as active' do
+      inactive_customer = FactoryGirl.create(:customer, active: false)
+
+      expect { Customer.activate }
+        .to change { inactive_customer.reload.active }
+    end
+  end
+
+  describe '#full_name' do
+    it 'is returns the customers full name' do
+      customer = FactoryGirl.build_stubbed(
+        :customer,
+        first_name: 'Tom',
+        last_name: 'Mullen'
+      )
+
+      result = customer.full_name
+
+      expect(result).to eq('Tom Mullen')
+    end
+  end
+end
+```

--- a/guides/templates/specs/requests.md
+++ b/guides/templates/specs/requests.md
@@ -1,0 +1,45 @@
+# Request Specs
+
+Request specs provide a thin wrapper around integration specs and are aimed at
+improving behavioural driven testing. By focusing on the inputs (inbound
+request) and outputs (end result), we can decouple the behviour of the
+application from our implementation.
+
+It is advised to stub as little as possible when writing your specs in order to
+replicate the user experience as closely as you can.
+
+The following is an example of how a request spec can help achieve that:
+
+```ruby
+require 'rails_helper'
+
+describe 'Updating a customer', type: :request do
+  context 'customer is not authenticated' do
+    it "denies access to customers#update" do
+      customer = FactoryGirl.create(:customer)
+      customer_attributes = { name: 'Tom' }
+
+      expect {
+        patch "/customers/#{customer.id}", { customer: customer_attributes }
+      }.to_not change { customer.reload.name }
+
+      expect(response).to redirect_to login_url
+    end
+  end
+
+  context 'customer is authenticated' do
+    it "denies access to customers#update" do
+      customer = FactoryGirl.create(:customer)
+      customer_attributes = { name: 'Tom' }
+
+      authenticate(customer)
+
+      expect {
+        patch "/customers/#{customer.id}", { customer: customer_attributes }
+      }.to change { customer.reload.name }
+
+      expect(response).to redirect_to customer_url(customer)
+    end
+  end
+end
+```

--- a/guides/templates/specs/services.md
+++ b/guides/templates/specs/services.md
@@ -1,0 +1,55 @@
+# Service Specs
+
+For each service, we would typically test it's public methods for expected
+behaviour, much like any other class.
+
+Example:
+
+```ruby
+require 'rails_helper'
+
+RSpec.describe Customers::Creator do
+  describe '#create' do
+    it 'returns a customer object' do
+      creator = described_class.new(params: customer_attributes)
+
+      result = creator.create
+
+      expected(result).to be_a(Customer)
+    end
+
+    context 'attributes are valid' do
+      it 'creates a customer' do
+        customer_attributes = FactoryGirl.attributes_for(:customer)
+        creator = described_class.new(params: customer_attributes)
+
+        expect { creator.create }
+          .to change { Customer.count }
+      end
+
+      it 'sends a welcome email' do
+        customer_attributes = FactoryGirl.attributes_for(:customer)
+        creator = described_class.new(params: customer_attributes)
+
+        allow(CustomerMailer).to receive(:welcome).and_call_original
+
+        creator.create
+
+        expect(CustomerMailer).to have_received(:welcome)
+          .with(Customer.last)
+      end
+    end
+
+    context 'attributes are invalid' do
+      it 'creates a customer' do
+        customer_attributes = {}
+        creator = described_class.new(params: customer_attributes)
+
+        expect { creator.create }
+          .to change { Customer.count }
+      end
+    end
+  end
+end
+```
+

--- a/guides/templates/specs/views.md
+++ b/guides/templates/specs/views.md
@@ -1,0 +1,24 @@
+# View Specs
+
+We don't tend to use view specs as regularly for the following reasons:
+
+  * Behaviour is covered by feature specs
+  * Views should only contain basic logic
+  * Views are implementation detail
+
+For those views where we do write specs, they would typically look like this:
+
+```ruby
+require 'rails_helper'
+
+describe 'customers/show.html.slim' do
+  it 'displays the customer name' do
+    customer = build_stubbed(:customer)
+    assign(:customer, customer)
+
+    render
+
+    rendered.should contain('Tom Mullen')
+  end
+end
+```


### PR DESCRIPTION
Why:

* As our team and our knowledge grows, it's helpful to have a reference
to how we approach common patterns in our code to help new joiners get
up-to-speed more quickly and ensure consistency across codebases.

This change addresses the need by:

* Adding guidelines and template for common patterns in our Rails
applications