### PR TITLE
Create diagnostics guide

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,6 +17,7 @@ better.
   * [Ruby gems](/guides/Creating%20Ruby%20Gems%20bespoke%20for%20DVELP.md)
   * [Shopify](/guides/Shopify.md)
   * [Trello](/guides/trello.md)
+  * [Diagnostics](/guides/diagnostics.md)
 
 * [Handbook](/handbook)
   * [Developer Proficiency](/handbook/developer-proficiency.md)

--- a/Readme.md
+++ b/Readme.md
@@ -10,6 +10,7 @@ better.
 * [Guides](/guides)
   * [Code Style](/guides/code-style/Readme.md)
   * [Design Guidelines](/guides/design-guidelines.md)
+  * [Diagnostics](/guides/diagnostics.md)
   * [Git](/guides/Git.md)
   * [Harvest Forecast](/guides/harvest-forecast.md)
   * [Heroku](/guides/Heroku%20Pipeline.md)
@@ -17,7 +18,7 @@ better.
   * [Ruby gems](/guides/Creating%20Ruby%20Gems%20bespoke%20for%20DVELP.md)
   * [Shopify](/guides/Shopify.md)
   * [Trello](/guides/trello.md)
-  * [Diagnostics](/guides/diagnostics.md)
+
 
 * [Handbook](/handbook)
   * [Developer Proficiency](/handbook/developer-proficiency.md)

--- a/guides/diagnostics.md
+++ b/guides/diagnostics.md
@@ -1,0 +1,75 @@
+# Diagnostics
+Shipping apps to a production environment is paramount in our development cycle. Having the correct tools in place to monitor and diagnose issues is essential.
+
+The following is the baseline setup for logging and error tracking in Rails applications at DVELP.
+
+## Naming
+
+Make sure you have the same names for Heroku application, sentry project and papertrail system. It's very important to keep all things with correct naming, e.g. `dvelp-production`
+
+## Logging
+
+### Papertrail
+
+For consistency and consolidation, we use a corporate [Papertrail](https://papertrailapp.com) account for logging purposes.
+
+### Setup
+
+Creating a new papertrail system for Heroku applications - [https://papertrailapp.com/systems/setup?type=app&platform=heroku]()
+
+### Lograge
+
+To prevent overly verbose logs, we recommend using [lograge](https://github.com/roidrage/lograge) to filter out the noise and provide more clarity.
+
+```ruby
+# config/initializers/lograge.rb
+
+Rails.application.configure do
+  config.lograge.enabled = Rails.env.production?
+  config.lograge.custom_options = lambda do |event|
+    exceptions = %w[controller action format]
+    {
+      params: event.payload[:params].except(*exceptions)
+    }
+  end
+end
+```
+
+If you’re using Rails 5's API-only mode and inherit from `ActionController::API`, you must define it as the controller base class which lograge will patch:
+
+```ruby
+config.lograge.base_controller_class = 'ActionController::API'
+```
+
+Use `info` log level to remove unnecessary debugging logs.
+```ruby
+# config/environments/production.rb
+
+config.log_level = :info
+```
+
+## Error Handling
+
+As with the [papertrail](https://papertrailapp.com) corporate account we have [Sentry](https://sentry.io) account. It's a service that helps you monitor an application crashes in realtime.
+
+### Setup
+To install Sentry for your application you have to do following steps:
+
+- Create [new project](https://sentry.io/organizations/dvelp/projects/new) on corporate account
+- Add `gem 'sentry-raven'` to your Gemfile and install the gem
+- Set `SENTRY_DSN` ENV variable. This value you can find on new account creation step
+
+To make sure your application doesn't send any confidential information like passwords, set sanitize fields:
+
+```
+# config/initializers/sentry.rb
+
+Raven.configure do |config|
+  config.sanitize_fields = Rails.application.config
+    .filter_parameters.map(&:to_s)
+end
+```
+
+### Slack integration
+
+Don't forget to add slack notifications to specific Slack channel. To enable this feature go to Sentry project settings and choose 'Alerts' section.

--- a/guides/diagnostics.md
+++ b/guides/diagnostics.md
@@ -5,7 +5,7 @@ The following is the baseline setup for logging and error tracking in Rails appl
 
 ## Naming
 
-Make sure you have the same names for Heroku application, sentry project and papertrail system. It's very important to keep all things with correct naming, e.g. `dvelp-production`
+Make sure you have the same names for Heroku application, sentry project and papertrail system e.g. `dvelp-production`. Consistency in naming conventions is very important.
 
 ## Logging
 
@@ -15,7 +15,7 @@ For consistency and consolidation, we use a corporate [Papertrail](https://paper
 
 ### Setup
 
-Creating a new papertrail system for Heroku applications - [https://papertrailapp.com/systems/setup?type=app&platform=heroku]()
+This [guide](https://papertrailapp.com/systems/setup?type=app&platform=heroku) will help you get Papertail set up on Heroku environments.
 
 ### Lograge
 
@@ -42,6 +42,7 @@ config.lograge.base_controller_class = 'ActionController::API'
 ```
 
 Use `info` log level to remove unnecessary debugging logs.
+
 ```ruby
 # config/environments/production.rb
 
@@ -50,14 +51,14 @@ config.log_level = :info
 
 ## Error Handling
 
-As with the [papertrail](https://papertrailapp.com) corporate account we have [Sentry](https://sentry.io) account. It's a service that helps you monitor an application crashes in realtime.
+We equally have a corporate [Sentry](https://sentry.io) account for error handling. Sentry is a service designed to help you monitor application issues in realtime.
 
 ### Setup
-To install Sentry for your application you have to do following steps:
+Complete the following steps to setup Sentry in your application:
 
-- Create [new project](https://sentry.io/organizations/dvelp/projects/new) on corporate account
-- Add `gem 'sentry-raven'` to your Gemfile and install the gem
-- Set `SENTRY_DSN` ENV variable. This value you can find on new account creation step
+- Create [new project](https://sentry.io/organizations/dvelp/projects/new) on the DVELP corporate account
+- Add `gem 'sentry-raven'` to your Gemfile and run `bundle install`
+- Set `SENTRY_DSN` ENV variable. Sentry will give you this when creating a new project (step 1).
 
 To make sure your application doesn't send any confidential information like passwords, set sanitize fields:
 
@@ -72,4 +73,4 @@ end
 
 ### Slack integration
 
-Don't forget to add slack notifications to specific Slack channel. To enable this feature go to Sentry project settings and choose 'Alerts' section.
+Don't forget to add notifications to your project Slack channel. To enable this feature go to Sentry project settings and choose 'Alerts' section.


### PR DESCRIPTION
Why:

* Create the doc where other developers could see our logging standards