### PR TITLE
Add mentoring guidelines

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,6 +23,7 @@ better.
 
 * [Handbook](/handbook)
   * [Developer Proficiency](/handbook/developer-proficiency.md)
+  * [Mentoring](/handbook/mentoring.md)
 
 * [Scripts](/scripts)
   * [Git Pull Requests](/scripts/git_merge_pull_request.sh)

--- a/handbook/mentoring.md
+++ b/handbook/mentoring.md
@@ -1,0 +1,76 @@
+# Mentoring
+
+At DVELP, we believe in `how` we do things. Although the end result is
+ultimately what we strive for, the steps we take to get there are extremely
+important.
+
+The belief in our process and a continued desire to improve it helps us to be
+more consistent as a team and more efficient in the day-to-day. It allows us to
+spend more time above the value line.
+
+As part of our commitment to this belief, we operate a mentor scheme to help new
+team members get up to speed.
+
+## What is expected of a mentor?
+
+As a mentor to any new recruit, your overarching aim is to share the knowledge
+you have, but importantly listen to new experiences and see how we can
+improve collectively.
+
+The following will help guide you:
+
+- Spend time **pair programming** to work through your current project or task
+  and share domain knowledge
+
+- **Discuss the fundamentals** such as Git (FF merges), linting and project
+  setup. The Cookbook is a great place to start
+
+- Explain how to **efficiently manage time** to create a sustainable but
+  productive working practice
+
+- Walk through the quirks of our **remote-first culture**, the fascination with
+  `afk` and the importance of fluid conversation regular updates
+
+- Post a picture of some kittens to the `#random` channel
+
+- Explain why we **obsess around the details** and how the small things, like
+  consistent naming conventions of environments help prevent catastrophe
+
+- Offer reassurance on **taking ownership for delivering code that works** and
+  how to ship it to production with confidence
+
+- **Review pull requests** and offer constructive advice on how to improve code
+  where possible
+
+- **Introduce existing team members** and share any key information about the
+  day-to-day running of the project you're working on
+
+
+## What can you expect as a mentee?
+
+As a newcomer to the team, you should at a minimum, expect the following from
+your assigned mentor and the wider team:
+
+- A **warm welcome**, followed by a one-on-one video call with all existing team
+  members
+
+- An **on-boarding session** from your mentor to help you understand the
+  ins-and-outs of how we do things, from development best practices (FF commits)
+  to time tracking and booking holidays
+
+- Support and advice writing your first few features and **shipping to
+  production**
+
+- A **point of contact** for any question, no matter how large or small
+
+- Help setting up all the relevant accounts (GitHub, Harvest, Charlie, Google
+  apps etc.)
+
+- An **introduction to the project and team** that you will be working with
+
+## How long should the mentorship last?
+
+The mentorship is aimed to help people become confident members of the team.
+The time required will change on a case-by-case basis, but we recommend that
+mentors give close support for at least the **first 4 weeks**.
+


### PR DESCRIPTION
Why:

* As our business grows, it's important that we not only make new
recruits comfortable, but also help them to learn about how we do things
and what we believe in

This change addresses the need by:

* Creating a document that both mentors and mentees can refer to during
the onboarding process