### PR TITLE
Add handbook README

### DIFF
--- a/handbook/README.md
+++ b/handbook/README.md
@@ -1,0 +1,78 @@
+# Handbook
+
+The following is a quick reference guide to the day-to-day operations at DVELP.
+
+* [General](#place-of-work)
+* [Developer Proficiency](developer-proficiency.md)
+* [Mentoring](mentoring.md)
+
+## Place of Work
+
+**DVELP is a remote-first company**. As the default, we expect all of our team to
+work remotely. We have a hub in London for those who wish to use it.
+
+## Communication
+
+As a remote-first team, communication is key to our day-to-day efficiency. We
+primarily use Slack, with a channel per project, but also expect our team to be
+responsive to email.
+
+Communication helps **promote transparency, breakdown barriers and build trust**.
+We encourage over communication at all times.
+
+## Meetings
+
+We aim to keep meetings to a minimum so it’s important we spend our time
+together efficiently.
+
+We run a weekly team stand-up at 10am on Mondays (London) and each project will
+typically have their own daily stand-up.
+
+Meetings give us the chance to share knowledge, understanding and our
+objectives as a team working together. We expect people to be **punctual, prepared
+and respectful of each others time**.
+
+## Time Management
+
+Our typical working day is 9am - 6pm (London).
+
+We understand that efficient working hours may differ from one individual to the
+next and we encourage flexibility. We must however respect the requirements of
+those who we work with to ensure we are available when required.
+
+For any extended time AFK (> 2 hours), we request that the relevant people are
+notified 24hrs in advance.
+
+## Deadlines & Overtime
+
+We work on projects, which from time-to-time, will have hard deadlines.
+
+Although we aim to prevent an increase in workload through careful planning, we
+understand longer days are sometimes required to meet a deadline.
+
+We don't operate an overtime remuneration structure, but we recommend that
+people take time off in lieu to rest-up.
+
+## Holidays
+
+Time-off is extremely important to our well-being. We encourage our team to make
+full use of their holiday allowance.
+
+We track holiday days in Charlie HR and request that holidays are booked at
+least 2 weeks in advance. We have a low-touch review process and aim to grant
+all holidays requested.
+
+We ask our team to use common sense when requesting holidays and be mindful of
+any pressing project deadlines or pre-existing holiday arrangements.
+
+**It is the responsibility of the individual to give sufficient notice to the
+team they are working with (internal and external) of any time off**
+
+Holiday days are not carried from one calendar year to the next.
+
+### Public Holidays
+
+Our team work from many different countries, each with their own public
+holidays. We request individuals follow the holidays set by their **country
+of residence** and within the parameters of the individuals allowance.
+


### PR DESCRIPTION
Why:

* We are aiming to give a distilled down version of the handbook that
will give both new and existing employees a clear point of reference to
the day-to-day operations at DVELP.

This change addresses the need by:

* Adding a README to the handbook section