### PR TITLE
Add support and maintenance agreement

### DIFF
--- a/guides/project-process/go-live-checklist.md
+++ b/guides/project-process/go-live-checklist.md
@@ -8,6 +8,7 @@ It should be reviewed at least once a sprint.
 
 ## Checklist
 
+- [ ] Hosting, maintenance and support [plans](maintenance-support-and-hosting.md) agreed
 - [ ] Rollout Plan agreed with stakeholders
 - [ ] Scoped requirements have been fully tested in staging (happy and unhappy paths)
 - [ ] Error tracking setup [Sentry](/guides/environments/diagnostics.md#error-handling) and being sent to the right places
@@ -19,7 +20,7 @@ It should be reviewed at least once a sprint.
 - [ ] Escalation process defined and shared with the client
 - [ ] Plan for how future production releases are handled
 
-## Plan
+## Go Live Plan
 
 For each major feature release to a production environment, we recommend you
 summarise the roll out plan in a document like

--- a/guides/project-process/maintenance-support-and-hosting.md
+++ b/guides/project-process/maintenance-support-and-hosting.md
@@ -1,0 +1,68 @@
+# Maintenance, Support & Hosting
+
+Ahead of [deploying a project to a live environment](/guides/project-process/go-live-checklist.md), 
+it's important to agree and organise maintenance, support and hosting.
+
+## Maintenance
+
+Our maintenance agreements allow us to dedicate a set number of days to your
+project each month. The dedicated hours are typically used for incremental
+improvements, small features and general housekeeping. Maintenance contracts are
+not analogous to [support](#support) and will not come with the same SLAs for
+issue response time.
+
+To make the most efficient use of allotted maintenance time, we recommend
+planning the work as far ahead as possible, so our team can prepare.
+
+Maintenance hours expire at the end of each month and cannot be carried over
+from one month to the next. Hours cannot be brought forwards. Work that is
+carried out over and above the allotted hours will be charged at a pre-agreed
+hourly rate.
+
+Maintenance contracts are paid up-front and the minimum contract length is 12
+months.
+
+
+## Support
+
+Our support packages allow us to be on-hand to help resolve any unexpected,
+unplanned issues that arise with your application.
+
+Our support agreements come in the following packages.
+
+|| Base | Plus | Enterprise |
+| ---- | ---- | ---- | ---- |
+| Cost | £1000 | £2500 | £5000 |
+| Email Support | Yes | Yes | Yes |
+| Telephone Support | Business day (8am-6pm) GMT | Business day (8am-6pm) GMT | 24/7 |
+| *Response Times* | | | |
+| [P1 - Business Critical](/bug-classifications.md) | 5 business hours | 2 business hours | 1 hour |
+| [P2 - Degraded Service](/bug-classifications.md) | 8 business hours | 4 business hours | 2 hours |
+| [P3 - General Issue](/bug-classifications.md) | 10 business hours | 6 business hours | 5 business hours |
+
+Support packages do not cover the professional services time & materials
+required to resolve an issue. Professional services are charged per hour, at a
+pre-agreed rate, with a 1 hour minimum call out charge.
+
+Where possible, we will attempt to resolve any reported issue before engaging
+an engineer.
+
+
+Support contracts are paid up-front and the minimum contract length is 12
+months.
+
+
+## Hosting
+
+We offer fully-managed, hosting packages. Packages come in the following plans
+to suit the need of the project or application.
+
+| Package | Detail | Cost (pcm) |
+| ---- | ---- | ---- |
+| Basic  | Single environment deployment (e.g. production only) | £180 per application |
+| Pipeline  | Dual environment deployment (e.g. staging and production) | £250 per application |
+| Pipeline Pro  | Triple environment deployment (e.g. development, staging and production) | £425 per application |
+
+N.B. All packages include logging, through [Papertrail](https://papertrailapp.com/) and error tracking, through [Sentry](https://sentry.io/).
+
+We run our applications on Heroku and will pass on their [customer promise](https://www.heroku.com/policy/promise).


### PR DESCRIPTION
Why:

* We often provide support, maintenance and hosting for our clients and
want to make this offering as transparent as possible.

This change addresses the need by:

* Adding the support, maintenance and hosting plan