### PR TITLE
InfoSec Security Charter + People Security

### DIFF
--- a/handbook/README.md
+++ b/handbook/README.md
@@ -32,10 +32,26 @@ This policy does not form part of any employee&#39;s contract of employment and 
   * [Risk Management Policy](risk-management/risk-management.md)
   * [Sickness Absence Policy](hr/absence.md)
   * [Time Management Policy](quick-reference.md#time-management)
-* Information Security
+* [Information Security](information-security/README.md)
+  * Access Management
+  * Asset Management
+  * Business Continuity Security
+  * Cloud and Network Infrastructure Security
+  * Communications Security
+  * Cryptography
   * [Data Protection Policy](information-security/data-protection-policy.md)
+  * Incident Responses
   * [Information and Communications Systems Policy](information-security/info-communication-policy.md)
+  * Operations Security
+  * [People Security](people-security.md)
+  * Physical Security
+  * Policies and Procedures
+  * Product Security
+  * Security Compliance
+  * Security Monitoring
+  * Third-Party Security
   * [Use of Cryptographic Controls Policy](information-security/use-of-cryptographic-controls-policy.md)
+  * Vulnerability Management
 * Professional Development
   * [Developer Proficiency](professional-development/developer-proficiency.md)
   * [Mentoring](professional-development/mentoring.md)

--- a/handbook/information-security/README.md
+++ b/handbook/information-security/README.md
@@ -1,0 +1,35 @@
+# Infomation Security Charter
+
+DVELP is committed to delivering an Information Security framework, inline
+with the ISO 27001 Information Security Standard, to improve the resiliency of
+business processes and foster awareness across our distributed team and amongst
+our customers.
+
+Security is represented at the highest level within the company. Our CEO
+meets regularly with the Executive Team to discuss issues and co-ordinate
+company wide initiatives.
+
+The framework, approved by management, is designed as a functional tool, to be
+referred to in the day-to-day, to improve awareness, define best practices and
+cystalise key processes for prevention and resolution of information security
+related issues.
+
+The framework includes programs covering:
+
+* Access Management
+* Asset Management
+* Business Continuity Security
+* Cloud and Network Infrastructure Security
+* Communications Security
+* Cryptography
+* Incident Responses
+* Operations Security
+* [People Security](people-security.md)
+* Physical Security
+* Policies and Procedures
+* Product Security
+* Security Compliance
+* Security Monitoring
+* Third-Party Security
+* Vulnerability Management
+

--- a/handbook/information-security/people-security.md
+++ b/handbook/information-security/people-security.md
@@ -1,0 +1,28 @@
+# People Security
+
+Our team is centric to everything we do, they are important to us. The following
+processes help ensure we continue to hire the right people and to keep them
+informed and up-to-date with relevant security trends and best practices.
+
+## Screening New Hires
+
+All U.K. candidates must pass a Standard Disclosure and Barring Service (DBS)
+check, to cover any criminal records, along with an Electronic Identity check.
+
+For all international hires, the background check must cover, where legal, any
+recorded criminal history.
+
+The employment history of all candidates will be verified through references
+from at least 2 former employers, where available.
+
+## Training
+
+All new hires will be introduced to our Charter and briefed on the information
+security 'fundamentals'. All employees are required to attend a security
+refresher session at least once a year, which covers Policy reviews and updates
+on best-practices.
+
+## In-Play
+
+Relevant updates, trends and process improvements are shared regularly and
+discussed with the team via the #iso27001 Slack channel.


### PR DESCRIPTION
### InfoSec Security Charter + People Security

Why:

* As part of preparation for the ISO27001 Information Security Standard,
we are adding pragmatic guides to help clarify our policies and
processes

This change addresses the need by:

* Setting out the Information Security Charter
* Adding a People Security Policy