### PR TITLE
Add anti-virus and malware policy

### DIFF
--- a/handbook/information-security/README.md
+++ b/handbook/information-security/README.md
@@ -17,6 +17,7 @@ related issues.
 The framework includes programs covering:
 
 * Access Management
+* [Anti-Virus and Malware Policy](anti-virus-malware-policy.md)
 * [Asset Acceptable Use Policy](acceptable-use.md)
 * [Asset Management](asset-management.md)
 * [Business Continuity Security](business-continuity.md)

--- a/handbook/information-security/anti-virus-malware-policy.md
+++ b/handbook/information-security/anti-virus-malware-policy.md
@@ -1,0 +1,42 @@
+# Anti-Virus & Malware Policy
+
+This document covers the requirements to protect against malicious code,
+including but not exclusive to viruses, Trojans, ransomware, mail bombs, worms
+and mobile code - collectively known as malware.
+
+Malicious code can result in data loss, system damage and potentially severe
+disruption in service, which can lead to reputational damage and failure to
+deliver on our customer promise.
+
+The following guidelines aim to protect, to an appropriate level, the desktops,
+laptops and mobile devices of employees and contractors who deliver
+services to and on behalf of DVELP Ltd.
+
+* **Anti-virus software** must be installed, running and kept up-to-date on a
+  weekly basis. If the software comes bundled as part of the Operating System
+  (Windows 10 and above or MacOSX), auto-system updates must be enabled and
+  installed within 1 day when prompted.
+
+* **Downloading and running software.** The following software should not be
+  downloaded or run on any device used for any activity relating to DVELP.
+
+  * Unlicensed software
+  * Freeware/shareware
+
+* **Spam, hoaxes and spear-fishing.** Many malware variants are sent via email,
+  illegitmate websites or targeted attacks. Be aware of email from unknown
+  senders, with topical subject lines and attachments. If you receive an email
+  suspected to be malicious, be sure not to forward it on.
+
+* **Firewalls and sharing services.** All devices that support a firewall must
+  have it enabled to prevent inbound and outbound traffic from unauthorised
+  applications. All sharing services (screen, file, internet) must be disabled
+  by default. In the event sharing is required by a trusted party, it may be
+  enabled for and disabled immediately after the session.
+
+
+Although these guidelines cannot guarantee to fully protect against malware and
+associated adverse effects, their aim is to reduce the risk to both individual
+and DVELP as a whole.
+
+In the event a virus or other malware is identified, please report it to the #iso27001 Slack channel.


### PR DESCRIPTION
Why:

* Viruses and other malware can cause data loss or sever service
disruption.

This change addresses the need by:

* Providing a policy to protect against malicious code.