### PR TITLE
Fix broken links to handbook readme

### DIFF
--- a/handbook/hr/off-boarding.md
+++ b/handbook/hr/off-boarding.md
@@ -7,5 +7,5 @@ This process is defined in a CharlieHR checklist which can be found
 [here](https://dvelp.charliehr.com/checklist_templates/4840).
 
 It is the joint responsibility of the individual's Line Manager and the [HR
-Manager](../readme.md#contacts) to ensure the off-boarding
+Manager](../README.md#contacts) to ensure the off-boarding
 checklist is completed.

--- a/handbook/hr/on-boarding.md
+++ b/handbook/hr/on-boarding.md
@@ -6,7 +6,7 @@ This process is defined in a CharlieHR checklist template which can be found
 [here](https://dvelp.charliehr.com/checklist_templates).
 
 It is the joint responsibility of the individual's Line Manager and the [HR
-Manager](../readme.md#contacts) to ensure the on-boarding
+Manager](../README.md#contacts) to ensure the on-boarding
 checklist is completed within one month of the new team member joining.
 
 # On-boarding advice from our team
@@ -18,7 +18,7 @@ joiners on their on-boarding journey.
 
 Overall information about cultural processes like meetings, time managment,
 communication is explained in [this quick reference
-guide](/handbook/quick-reference.md).  We recomend you read this before anything
+guide](/handbook/quick-reference.md). We recomend you read this before anything
 else.
 
 ## Acquaintance with your mentor
@@ -82,4 +82,3 @@ quesitons.
   useful when you need to get access to some system.
 - [Our blog](https://dvelp.co.uk/articles) - This contains a lot of articles
   that explain our approach and expertise in everything we do.
-

--- a/handbook/hr/referral-programme.md
+++ b/handbook/hr/referral-programme.md
@@ -2,10 +2,11 @@
 
 We run a candidate referral program at DVELP. If you recommend a candidate for a role we
 are looking to fill and that candidate gets hired and passes his/her probation
-period, you will will receive an extra £500 in your next pay cheque. 
+period, you will will receive an extra £500 in your next pay cheque.
 
 To manage this process, we are using Greenhouse.io, our Applicant Tracking
 System:
+
 1. Log into [Greenhouse.io](https://www.greenhouse.io/login)
 2. Go to "All Jobs" to see the jobs for which you can submit candidates
 3. Select a job

--- a/handbook/operations/greenhouse.md
+++ b/handbook/operations/greenhouse.md
@@ -9,31 +9,32 @@ Greenhouse is a great tool to coordinate the hiring process. However, in order
 for us to be able to rely on it, we need to follow these rules:
 
 **1. All candidates must go through Greenhouse**
-  * If you come across a candidate that is not yet in Greenhouse:
-    * please create them on Greenhouse, uploading their CV if available
-    * if the candidate came through a recruiter please ask the recruiter to
-      upload the candidate to our Greenhouse portal, so that they are tracked as
-the source of the candidate - If the recruiter does not yet have access to our
-Greenhouse portal, please ask the [Greenhouse System
-Admin](../readme.md#contacts) to set this up
+
+- If you come across a candidate that is not yet in Greenhouse:
+  _ please create them on Greenhouse, uploading their CV if available
+  _ if the candidate came through a recruiter please ask the recruiter to
+  upload the candidate to our Greenhouse portal, so that they are tracked as
+  the source of the candidate - If the recruiter does not yet have access to our
+  Greenhouse portal, please ask the [Greenhouse System
+  Admin](../README.md#contacts) to set this up
 
 **2. All communication about a candidate must go through Greenhouse**
-  * If we discuss candidates via email or Slack, the information is not
-    available to the whole team and likely to be forgotton
-  * Therefore, when emailing:
-    * Send emails relating to a candidate from within Greenhouse (click the
-      **Email Candidate** or **Email Team** button in the candidate's profile)
-    * Always CC the recruiter, so that they are up to speed with latest
-      developments, as well as <flyonthewall@ivy.greenhouse.io>, which makes
-sure that any responses to your email are tracked in Greenhouse
-    * When a recruiter and/or candidate emails you directly, reply from within
-      Greenhouse
-  * For shorter messages you can use @mentions in the **Make a Note** section on
-    the candidate profile. This will result in an email notification to the
-individual
-  * If you have an offline conversation about a candidate, make sure the
-    conclusions of this conversation are captured using the **Make a Note**
-field
+
+- If we discuss candidates via email or Slack, the information is not
+  available to the whole team and likely to be forgotton
+- Therefore, when emailing:
+  _ Send emails relating to a candidate from within Greenhouse (click the
+  **Email Candidate** or **Email Team** button in the candidate's profile)
+  _ Always CC the recruiter, so that they are up to speed with latest
+  developments, as well as <flyonthewall@ivy.greenhouse.io>, which makes
+  sure that any responses to your email are tracked in Greenhouse \* When a recruiter and/or candidate emails you directly, reply from within
+  Greenhouse
+- For shorter messages you can use @mentions in the **Make a Note** section on
+  the candidate profile. This will result in an email notification to the
+  individual
+- If you have an offline conversation about a candidate, make sure the
+  conclusions of this conversation are captured using the **Make a Note**
+  field
 
 ## Activity Feed
 
@@ -47,4 +48,4 @@ avoided.
 ## Questions
 
 Any questions you have about the platform or our process can be directed at the
-[Greenhouse System Admin](../readme.md#contacts).
+[Greenhouse System Admin](../README.md#contacts).


### PR DESCRIPTION
Links on github are case-sensitive - so had to change `readme.md` to `README.MD` in some cases